### PR TITLE
fix: close remaining known-folder CodeQL alert

### DIFF
--- a/crates/bentodesk-platform/src/storage/paths.rs
+++ b/crates/bentodesk-platform/src/storage/paths.rs
@@ -136,11 +136,7 @@ fn roaming_state_dir() -> Result<PathBuf, PlatformError> {
             hr,
         });
     }
-    if raw.is_null() {
-        return Err(PlatformError::Null {
-            ctx: "SHGetKnownFolderPath",
-        });
-    }
+    let raw = known_folder_non_null(raw)?.as_ptr();
 
     // Walk the UTF-16 string to its NUL terminator.
     // SAFETY: pointer checked above; bounded by the OS-supplied NUL.
@@ -163,6 +159,12 @@ fn roaming_state_dir() -> Result<PathBuf, PlatformError> {
     let mut path = PathBuf::from(s);
     path.push("BentoDesk");
     Ok(path)
+}
+
+fn known_folder_non_null(raw: *mut u16) -> Result<core::ptr::NonNull<u16>, PlatformError> {
+    core::ptr::NonNull::new(raw).ok_or(PlatformError::Null {
+        ctx: "SHGetKnownFolderPath",
+    })
 }
 
 fn state_dir_override_path() -> Option<PathBuf> {
@@ -217,5 +219,20 @@ pub fn quarantine_corrupt(path: &Path) -> Result<(), PlatformError> {
             ctx: "rename to quarantine",
             kind: e.kind(),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_known_folder_path_is_rejected_before_dereference() {
+        assert!(matches!(
+            known_folder_non_null(core::ptr::null_mut()),
+            Err(PlatformError::Null {
+                ctx: "SHGetKnownFolderPath"
+            })
+        ));
     }
 }


### PR DESCRIPTION
## Root cause

CodeQL alert #30 still found a possible invalid pointer dereference in
`storage/paths.rs` after the native 2.0 merge. The sibling
`desktop_sources.rs` path was already fixed with an explicit `NonNull`
conversion, but roaming AppData still used a raw null check before its UTF-16
walk.

## Fix

- convert the Shell-owned pointer to `NonNull<u16>` before any dereference;
- preserve the existing typed `PlatformError::Null` failure;
- add a focused null-pointer regression test.

## Local verification

- `cargo fmt --all -- --check`
- focused test: 1 passed
- `cargo clippy --locked -p bentodesk-platform --all-targets --target x86_64-pc-windows-msvc -- -D warnings`
- `cargo +1.89.0 check --locked -p bentodesk-platform --target x86_64-pc-windows-msvc`

Release remains blocked until the new main-branch CodeQL analysis reports zero
open alerts.
