### PR TITLE
ci: enforce the declared Rust 1.89 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
   CARGO_BUILD_JOBS: "1"
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
+  MSRV_TOOLCHAIN: "1.89.0"
   RUSTUP_TOOLCHAIN: "1.94.0"
   RUST_BACKTRACE: "1"
   TARGET: x86_64-pc-windows-msvc
@@ -38,9 +39,15 @@ jobs:
         run: |
           $PSNativeCommandUseErrorActionPreference = $true
           rustup toolchain install $env:RUSTUP_TOOLCHAIN --profile minimal --component rustfmt,clippy --target $env:TARGET
+          rustup toolchain install $env:MSRV_TOOLCHAIN --profile minimal --target $env:TARGET
           rustup show active-toolchain
           rustc --version
           cargo --version
+
+      - name: Minimum supported Rust
+        env:
+          RUSTFLAGS: ""
+        run: cargo +$env:MSRV_TOOLCHAIN check --locked --workspace --all-targets --target $env:TARGET
 
       - name: Remap build-machine paths
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ env:
   CARGO_BUILD_JOBS: "1"
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
+  MSRV_TOOLCHAIN: "1.89.0"
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
   RUSTUP_TOOLCHAIN: "1.94.0"
   TARGET: x86_64-pc-windows-msvc
@@ -45,7 +46,13 @@ jobs:
         run: |
           $PSNativeCommandUseErrorActionPreference = $true
           rustup toolchain install $env:RUSTUP_TOOLCHAIN --profile minimal --component rustfmt,clippy --target $env:TARGET
+          rustup toolchain install $env:MSRV_TOOLCHAIN --profile minimal --target $env:TARGET
           rustup show active-toolchain
+
+      - name: Minimum supported Rust
+        env:
+          RUSTFLAGS: ""
+        run: cargo +$env:MSRV_TOOLCHAIN check --locked --workspace --all-targets --target $env:TARGET
 
       - name: Remap build-machine paths
         shell: pwsh


### PR DESCRIPTION
## Summary

- install the declared Rust 1.89 toolchain in protected CI and release jobs
- run an all-target workspace check with Rust 1.89 before normal 1.94 validation
- isolate the MSRV check from application linker flags with an empty `RUSTFLAGS`

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `RUSTFLAGS="" CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo +1.89.0 check --locked --workspace --all-targets --target x86_64-pc-windows-msvc`

This hardens future changes; the immutable v2.0.2 release and tag are unchanged.