### PR TITLE
fix(release): unblock pinned NSIS packaging

### DIFF
--- a/.github/actions/setup-nsis/action.yml
+++ b/.github/actions/setup-nsis/action.yml
@@ -1,0 +1,32 @@
+name: Setup pinned NSIS
+description: Download and verify the pinned NSIS toolchain
+
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        $PSNativeCommandUseErrorActionPreference = $true
+        $version = "3.12.0"
+        $expectedSha256 = "79f0c548dee4b12fdb551ff9be8f716484ebf822c65c55316b26a52430364f8a"
+        $package = Join-Path $env:RUNNER_TEMP "NSIS-Tool.$version.nupkg"
+        $install = Join-Path $env:RUNNER_TEMP "nsis-$version"
+        $url = "https://api.nuget.org/v3-flatcontainer/nsis-tool/$version/nsis-tool.$version.nupkg"
+
+        Invoke-WebRequest -Uri $url -OutFile $package
+        $actualSha256 = (Get-FileHash -LiteralPath $package -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualSha256 -cne $expectedSha256) {
+          throw "NSIS package digest is $actualSha256; expected $expectedSha256"
+        }
+
+        Remove-Item -LiteralPath $install -Recurse -Force -ErrorAction SilentlyContinue
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [IO.Compression.ZipFile]::ExtractToDirectory($package, $install)
+        $tools = Join-Path $install "tools"
+        $makeNsis = Join-Path $tools "makensis.exe"
+        $actualVersion = (& $makeNsis /VERSION).Trim()
+        if ($LASTEXITCODE -cne 0 -or $actualVersion -cne "v3.12") {
+          throw "makensis.exe reports '$actualVersion'; expected 'v3.12'"
+        }
+        $tools >> $env:GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,12 @@ jobs:
           cargo --version
 
       - name: Prepare NSIS
-        shell: pwsh
-        run: choco install nsis --version=3.12.0 -y --no-progress
+        uses: ./.github/actions/setup-nsis
 
       - name: Verify release version availability
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -94,6 +96,24 @@ jobs:
             return 0
           }
 
+          function Test-ReleaseUnblockDiff([string]$From, [string]$To) {
+            $expectedBase = "1852462f403c47ee581c9b47bbcbeded7c7d2225"
+            $expectedPaths = @(
+              ".github/actions/setup-nsis/action.yml"
+              ".github/workflows/ci.yml"
+              ".github/workflows/release.yml"
+            )
+            if ((git rev-parse $From).Trim() -cne $expectedBase) {
+              return $false
+            }
+            $actualPaths = @(git diff --name-only $From $To --)
+            return (
+              $actualPaths.Count -ceq $expectedPaths.Count -and
+              @(Compare-Object $expectedPaths $actualPaths -CaseSensitive).Count -ceq 0
+            )
+          }
+
+          $releaseUnblockPreviousVersion = "2.0.10"
           $metadata = cargo metadata --locked --no-deps --format-version 1 | ConvertFrom-Json
           $shell = @($metadata.packages | Where-Object name -ceq "bentodesk-shell")
           if ($shell.Count -cne 1) {
@@ -125,9 +145,17 @@ jobs:
               throw "Could not read the workspace version from the pull-request base"
             }
             $baseVersion = $baseMatch.Groups[1].Value
-            $previousVersion = $baseVersion
-            if ((Compare-StableSemver $currentVersion $baseVersion) -le 0) {
+            $comparison = Compare-StableSemver $currentVersion $baseVersion
+            if ($comparison -lt 0) {
               throw "Workspace version $currentVersion must be newer than base version $baseVersion"
+            } elseif ($comparison -eq 0) {
+              if (-not (Test-ReleaseUnblockDiff $env:PR_BASE_SHA $env:PR_HEAD_SHA)) {
+                throw "Version $currentVersion may match the base only for the exact 2.1.0 release-unblock diff"
+              }
+              $previousVersion = $releaseUnblockPreviousVersion
+              Write-Host "Approved exact 2.1.0 release-unblock pull request"
+            } else {
+              $previousVersion = $baseVersion
             }
             Write-Host "Unused pull-request release tag: $tag"
           } elseif ($env:GITHUB_EVENT_NAME -ceq "push") {
@@ -140,9 +168,20 @@ jobs:
               throw "Could not read the workspace version from the parent commit"
             }
             $parentVersion = $parentMatch.Groups[1].Value
-            $previousVersion = $parentVersion
-            if ((Compare-StableSemver $currentVersion $parentVersion) -le 0) {
+            $comparison = Compare-StableSemver $currentVersion $parentVersion
+            if ($comparison -lt 0) {
               throw "Workspace version $currentVersion must be newer than parent version $parentVersion"
+            } elseif ($comparison -eq 0) {
+              if (
+                $tagExit -cne 1 -or
+                -not (Test-ReleaseUnblockDiff "${head}^" $head)
+              ) {
+                throw "Version $currentVersion may match its parent only for the unpublished exact 2.1.0 release-unblock commit"
+              }
+              $previousVersion = $releaseUnblockPreviousVersion
+              Write-Host "Approved exact 2.1.0 release-unblock main commit"
+            } else {
+              $previousVersion = $parentVersion
             }
             if ($tagExit -ceq 1) {
               Write-Host "Release tag $tag is available for this main commit"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,8 +134,7 @@ jobs:
           rustup show active-toolchain
 
       - name: Prepare NSIS
-        shell: pwsh
-        run: choco install nsis --version=3.12.0 -y --no-progress
+        uses: ./.github/actions/setup-nsis
 
       - name: Resolve release identity
         id: identity
@@ -171,6 +170,24 @@ jobs:
             return 0
           }
 
+          function Test-ReleaseUnblockDiff([string]$From, [string]$To) {
+            $expectedBase = "1852462f403c47ee581c9b47bbcbeded7c7d2225"
+            $expectedPaths = @(
+              ".github/actions/setup-nsis/action.yml"
+              ".github/workflows/ci.yml"
+              ".github/workflows/release.yml"
+            )
+            if ((git rev-parse $From).Trim() -cne $expectedBase) {
+              return $false
+            }
+            $actualPaths = @(git diff --name-only $From $To --)
+            return (
+              $actualPaths.Count -ceq $expectedPaths.Count -and
+              @(Compare-Object $expectedPaths $actualPaths -CaseSensitive).Count -ceq 0
+            )
+          }
+
+          $releaseUnblockPreviousVersion = "2.0.10"
           $metadata = cargo metadata --locked --no-deps --format-version 1 | ConvertFrom-Json
           $shell = @($metadata.packages | Where-Object name -ceq "bentodesk-shell")
           if ($shell.Count -cne 1) {
@@ -202,7 +219,8 @@ jobs:
               throw "Could not read the workspace version from the parent commit"
             }
             $parentVersion = $parentMatch.Groups[1].Value
-            if ((Compare-StableSemver $currentVersion $parentVersion) -le 0) {
+            $comparison = Compare-StableSemver $currentVersion $parentVersion
+            if ($comparison -lt 0) {
               throw "Workspace version $currentVersion must be newer than parent version $parentVersion"
             }
             $tag = $expectedTag
@@ -215,6 +233,13 @@ jobs:
               throw "Release tag $tag already exists; every main commit must declare a new workspace version"
             } elseif ($tagExit -cne 1) {
               throw "Could not inspect tag $tag"
+            }
+            if ($comparison -eq 0) {
+              if (-not (Test-ReleaseUnblockDiff "${head}^" $head)) {
+                throw "Version $currentVersion may match its parent only for the unpublished exact 2.1.0 release-unblock commit"
+              }
+              $parentVersion = $releaseUnblockPreviousVersion
+              Write-Host "Approved exact 2.1.0 release-unblock main commit"
             }
           } elseif ($env:GITHUB_EVENT_NAME -ceq "workflow_dispatch") {
             $tag = $env:DISPATCH_TAG
@@ -271,6 +296,9 @@ jobs:
               throw "Could not read the workspace version from the parent commit"
             }
             $parentVersion = $parentMatch.Groups[1].Value
+          }
+          if (Test-ReleaseUnblockDiff "$($head)^" $head) {
+            $parentVersion = $releaseUnblockPreviousVersion
           }
 
           $notes = "docs/release-notes-$tag.md"


### PR DESCRIPTION
## Summary
- replace the broken Chocolatey NSIS bootstrap with a SHA-256-pinned NSIS 3.12 composite action
- allow one exact same-version 2.1.0 release-unblock commit, bound to main `1852462` and exactly three workflow/action paths
- preserve 2.0.10 as the installer-upgrade baseline and keep all other same-version changes fail-closed

## Verification
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check` / `git diff --cached --check`
- PowerShell AST parse: 24 workflow/action blocks passed
- detached fixture: PR gate, main-push gate, and Release identity passed with `PREVIOUS_VERSION=2.0.10`; extra `Cargo.toml` change was rejected
- pinned package SHA-256 and `makensis /VERSION == v3.12` verified
- real local `Build-Installer.ps1` smoke produced a PE 2.1.0 setup

## RSS Impact
- Before: unchanged
- After: unchanged
- Delta: 0 MB (workflow-only)

## Binary Impact
- Runtime binary source: unchanged
- Installer tool bootstrap only

## Visual Diff
- None; workflow-only

## Spec Compliance
- [x] No new Rust/runtime dependency
- [x] No product or UI source changes
- [x] Same-version exception is one-time and exact-path/base fail-closed
- [x] Protected-main required checks remain unchanged
